### PR TITLE
Change base Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine as exporter
+FROM python:3.12.5-bookworm AS exporter
 ARG DEBIAN_FRONTEND=noninteractive
 RUN pip3 install \
     prometheus_client==0.20.0 \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all ci docker_build docker_retag docker_login docker_push
 
-VERSION            := 2.1.2
+VERSION            := 2.2.0
 PROJECT_NAME       ?= amneziavpn/amneziawg-exporter
 DOCKER_BUILDKIT    ?= 1
 DOCKER_REGISTRY    ?= docker.io

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # AmneziaWG exporter
 
-amneziawg-exporter is a Prometheus exporter for gathering AmneziaWG client connection metrics.
+AmneziaWG exporter is a Prometheus exporter for gathering AmneziaWG client connection metrics.
 
 ## Features and limitations
 
@@ -63,7 +63,7 @@ You can use example [docker-compose.yml](docker-compose.yml) with Docker Compose
  ✔ Container amneziawg-exporter  Started                                                                                                                  0.2s 
 # docker compose ps
 NAME                 IMAGE                                          COMMAND                         SERVICE              CREATED          STATUS          PORTS
-amneziawg-exporter   amneziavpn/amneziawg-exporter:2.1.0            "/usr/bin/amneziawg-exporter"   amneziawg-exporter   23 seconds ago   Up 23 seconds
+amneziawg-exporter   amneziavpn/amneziawg-exporter:latest           "/usr/bin/amneziawg-exporter"   amneziawg-exporter   23 seconds ago   Up 23 seconds
 ```
 
 > [!TIP]


### PR DESCRIPTION
Change base Docker Image to `python:3.12.5-bookworm` in order to execute `/usr/bin/awg` without issues. In addition, improve `README.md`.