### PR TITLE
Switch Docker Image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.12.5-slim-bookworm AS exporter
-ARG DEBIAN_FRONTEND=noninteractive
-RUN pip3 install --no-cache-dir \
+FROM ubuntu:24.04 AS exporter
+RUN apt-get update && \
+    apt-get install python3-pip -y && \
+    pip3 install --no-cache-dir --break-system-packages \
     prometheus_client==0.20.0 \
     python-decouple==3.8 \
     requests==2.32.3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all ci docker_build docker_retag docker_login docker_push
 
-VERSION            := 2.4.0
+VERSION            := 2.5.0
 PROJECT_NAME       ?= amneziavpn/amneziawg-exporter
 DOCKER_BUILDKIT    ?= 1
 DOCKER_REGISTRY    ?= docker.io

--- a/exporter.py
+++ b/exporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import sys


### PR DESCRIPTION
Switching to the Ubuntu distribution ensures compatibility with modern kernels and fresh version of glibc, which aligns better with the host system.